### PR TITLE
Handle pebble-ready

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,9 @@
 name: Test Suite
-on: [push]
+on:
+  - push:
+      branches: [main]
+  - pull_request:
+      branches: [main]
 
 jobs:
   lint-and-unit:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,9 +1,9 @@
 name: Test Suite
 on:
-  - push:
-      branches: [main]
-  - pull_request:
-      branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   lint-and-unit:


### PR DESCRIPTION
Ensure that we handle the `pebble-ready` event, as well as connection errors that might happen from events (such as `config-change`) happening before Pebble is ready.

Also report a status when we don't have an ingress address to send over the relation, and refine when Actions are run on GitHub.