### PR TITLE
Switch libjuju to master

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,10 +28,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@master
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,8 @@ commands = pytest -v --tb native -s {posargs:tests/unit}
 
 [testenv:integration]
 deps =
-    # Temporarily use branch until fix lands / is released.
-    https://github.com/juju/python-libjuju/archive/refs/heads/johnsca/lp-1929076/fix-series-metadata-v2.zip#egg=juju
+    # Temporarily use master until next release (after 2.9.0).
+    https://github.com/juju/python-libjuju/archive/refs/heads/master.zip#egg=juju
     juju
     pytest
     pytest-operator 


### PR DESCRIPTION
Since [libjuju #504][] was merged, switch libjuju to master branch until next release. Also try removing setup-python step since `ubuntu-latest` should now come with at least 3.8 anyway.

[libjuju #504]: https://github.com/juju/python-libjuju/pull/504