### PR TITLE
Use libjuju fork to enable deploying prometheus in integration tests

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -10,12 +10,13 @@ log = logging.getLogger(__name__)
 async def test_build_and_deploy(ops_test):
     ksm_charm = await ops_test.build_charm(".")
 
-    # NB: We can't use a bundle for now due to https://github.com/juju/python-libjuju/issues/506
+    # NB: We can't use a bundle for now
+    # due to https://github.com/juju/python-libjuju/issues/506
     await ops_test.model.deploy(
         ksm_charm,
         config={"scrape-interval": "5s"},
         resources={
-            "kube-state-metrics-image": "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0"
+            "kube-state-metrics-image": "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.0.0"  # noqa: E501
         },
         trust=True,  # so that the container can access k8s api
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -20,7 +20,7 @@ async def test_build_and_deploy(ops_test):
         },
         trust=True,  # so that the container can access k8s api
     )
-    await ops_test.model.deploy("prometheus-k8s", channel="latest/beta", trust=True)
+    await ops_test.model.deploy("prometheus-k8s", channel="latest/edge", trust=True)
     await ops_test.model.add_relation("kube-state-metrics", "prometheus-k8s")
     await ops_test.model.wait_for_idle(wait_for_active=True)
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands = pytest -v --tb native -s {posargs:tests/unit}
 
 [testenv:integration]
 deps =
-    juju
+    git+https://github.com/charmed-kubernetes/python-libjuju.git@2.9.11+ck1
     pytest
     pytest-operator 
     ipdb


### PR DESCRIPTION
libjuju is unable to deploy prometheus-k8s pre 3.0. However 3.0+ also has [issues with actions](https://github.com/juju/python-libjuju/issues/719). Using the fork allows us to deploy prometheus-k8s and also reliably use actions in integration tests.